### PR TITLE
Fix rare pagination error.

### DIFF
--- a/django_describer/adapters/graphql/pagination.py
+++ b/django_describer/adapters/graphql/pagination.py
@@ -28,4 +28,4 @@ class LimitOffsetOrderingGraphqlPagination(LimitOffsetGraphqlPagination):
 
         offset = kwargs.get(self.offset_query_param, 0)
 
-        return qs[offset: offset + fabs(limit)]
+        return qs[offset: offset + int(fabs(limit))]


### PR DESCRIPTION
Python slices do not accept floats. This sometimes breaks pagination (specifically the `limit` argument) on lists.

To be even more specific, this error only affects the `exam` module of LearnShell and no others.

As can be seen in the diff, the fix is a very small change.